### PR TITLE
Remove warning when using with gatsby version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "prettier": "1.14.2"
   },
   "peerDependencies": {
-    "gatsby": "next"
+    "gatsby": "^2.0.0"
   }
 }


### PR DESCRIPTION
`warning Plugin gatsby-remark-reading-time is not compatible with your gatsby version 2.0.67 - It requires gatsby@next`

Remove warning in console when using with gatsby version 2