### PR TITLE
Add support for MDX

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,5 +8,11 @@ exports.onCreateNode = ({ node, actions }) => {
       name: `readingTime`,
       value: readingTime(node.rawMarkdownBody),
     });
+  } else if (node.internal.type === `Mdx`) {
+    createNodeField({
+      node,
+      name: `readingTime`,
+      value: readingTime(node.rawBody),
+    });
   }
 };


### PR DESCRIPTION
First, thanks for this plugin!

# Summary

Adds support for the `Mdx` node type provided via `gatsby-plugin-mdx`. 

Although `gatsby-plugin-mdx` provides a similar metric via `timeToRead` field, I believe this plugin continues to offer value alongside the mdx plugin, as it provides additional formatting options. 

## Notes
1. To have this work with `gatsby-plugin-mdx`, this plugin needs to live outside of the `gatsby-plugin-mdx` options, e.g `remarkPlugins` or `gatsbyRemarkPlugins`. For example, 

```js
// gatsby-config.js
  ...
  plugins: [
    {
      resolve: `gatsby-plugin-mdx`,
      options: {
        gatsbyRemarkPlugins: [...],
        remarkPlugins: [...],
      },
    },
    'gatsby-remark-reading-time',
     ...
  ],