### PR TITLE
Update peerDependency gatsby version to support 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "prettier": "1.14.2"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
## Fix npm install on gatsby@4.x.x occur error

### Updated package.json 
- Add gatsby 4.x.x on peer dependency.